### PR TITLE
Improves ido-recentf-open

### DIFF
--- a/config/editing-setup.el
+++ b/config/editing-setup.el
@@ -82,9 +82,12 @@
 (defun ido-recentf-open ()
   "Use `ido-completing-read' to \\[find-file] a recent file"
   (interactive)
-  (if (find-file (ido-completing-read "Find recent file: " recentf-list))
+  (if (find-file
+       (ido-completing-read
+        "Find recent file: "
+        (mapcar 'abbreviate-file-name recentf-list) nil t))
       (message "Opening file...")
-      (message "Aborting")))
+    (message "Aborting")))
 
 ;; Line number based navigation
 (defun goto-line-with-feedback ()


### PR DESCRIPTION
Two main improvements over the old version:
- Expands ~ to your home directory
- Doesn't have the bug preventing you from opening your most recent file (if you press C-x f then enter with the old version, it barely ever works)

Written by Steve Purcell:
http://www.reddit.com/r/emacs/comments/21a4p9/use_recentf_and_ido_together/cgc8f6b
