### PR TITLE
Use stable versions of crucial Clojure packages

### DIFF
--- a/lisp/init-packages.el
+++ b/lisp/init-packages.el
@@ -6,8 +6,12 @@
 (add-to-list 'package-archives
              '("melpa" . "http://melpa.milkbox.net/packages/") t)
 
-(setq package-pinned-archives '((clojure-mode . "melpa-stable")
-                                (cider . "melpa-stable")))
+;; This allows you to specify what repository to download a particular package from
+;; But it only works on Emacs 24.4, and pretest versions are given a 24.3 numbering scheme,
+;; so to make things simple we'll just ignore any potential errors
+(ignore-errors
+  (setq package-pinned-archives '((clojure-mode . "melpa-stable")
+                                  (cider . "melpa-stable"))))
 
 ;; On demand installation of packages
 (defun require-package (package &optional min-version no-refresh)


### PR DESCRIPTION
I cleared out my `elpa` directory and started fresh - everything seems to work and the errors caused by the mismatch between the Emacs CIDER and installed CIDER are gone.

Sadly pinned packages only work as long as you're using a pretest version of Emacs 24.4; the variable will just be ignored for anyone with an outdated Emacs. Added ignore-errors just to be safe though.
